### PR TITLE
Update project to .NET 9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ VillageGame/
 
 ### Prerequisites
 
-- .NET 7.0 SDK or later
+- .NET 9.0 SDK or later
 - MonoGame Framework
 - Visual Studio 2022 or JetBrains Rider
 - Git

--- a/src/VillageGame.Core/VillageGame.Core.csproj
+++ b/src/VillageGame.Core/VillageGame.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/VillageGame.Game/VillageGame.Game.csproj
+++ b/src/VillageGame.Game/VillageGame.Game.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishReadyToRun>false</PublishReadyToRun>

--- a/src/VillageGame.Infrastructure/VillageGame.Infrastructure.csproj
+++ b/src/VillageGame.Infrastructure/VillageGame.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -10,7 +10,7 @@
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.14" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VillageGame.Tests/Core/DataStoreTests.cs
+++ b/src/VillageGame.Tests/Core/DataStoreTests.cs
@@ -47,8 +47,8 @@ namespace VillageGame.Tests.Core
             var loadedValue = await _dataStore.LoadDataAsync<string>(key);
             
             // Assert
-            Assert.IsTrue(saveResult, "Save operation should succeed");
-            Assert.AreEqual(value, loadedValue, "Loaded value should match saved value");
+            Assert.That(saveResult, Is.True, "Save operation should succeed");
+            Assert.That(loadedValue, Is.EqualTo(value), "Loaded value should match saved value");
         }
         
         [Test]
@@ -68,10 +68,10 @@ namespace VillageGame.Tests.Core
             var loadedValue = await _dataStore.LoadDataAsync<TestData>(key);
             
             // Assert
-            Assert.IsTrue(saveResult, "Save operation should succeed");
-            Assert.IsNotNull(loadedValue, "Loaded value should not be null");
-            Assert.AreEqual(value.Id, loadedValue.Id, "Loaded Id should match saved Id");
-            Assert.AreEqual(value.Name, loadedValue.Name, "Loaded Name should match saved Name");
+            Assert.That(saveResult, Is.True, "Save operation should succeed");
+            Assert.That(loadedValue, Is.Not.Null, "Loaded value should not be null");
+            Assert.That(loadedValue.Id, Is.EqualTo(value.Id), "Loaded Id should match saved Id");
+            Assert.That(loadedValue.Name, Is.EqualTo(value.Name), "Loaded Name should match saved Name");
         }
         
         [Test]
@@ -86,7 +86,7 @@ namespace VillageGame.Tests.Core
             var exists = await _dataStore.KeyExistsAsync(key);
             
             // Assert
-            Assert.IsTrue(exists, "Key should exist after saving data");
+            Assert.That(exists, Is.True, "Key should exist after saving data");
         }
         
         [Test]
@@ -99,7 +99,7 @@ namespace VillageGame.Tests.Core
             var exists = await _dataStore.KeyExistsAsync(key);
             
             // Assert
-            Assert.IsFalse(exists, "Key should not exist if not saved");
+            Assert.That(exists, Is.False, "Key should not exist if not saved");
         }
         
         [Test]
@@ -115,8 +115,8 @@ namespace VillageGame.Tests.Core
             var exists = await _dataStore.KeyExistsAsync(key);
             
             // Assert
-            Assert.IsTrue(deleteResult, "Delete operation should succeed");
-            Assert.IsFalse(exists, "Key should not exist after deletion");
+            Assert.That(deleteResult, Is.True, "Delete operation should succeed");
+            Assert.That(exists, Is.False, "Key should not exist after deletion");
         }
         
         private class TestData

--- a/src/VillageGame.Tests/VillageGame.Tests.csproj
+++ b/src/VillageGame.Tests/VillageGame.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.10.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
     This PR updates the project from .NET 7.0 to .NET 9.0.

     Changes include:
     - Updated all project files to target net9.0 instead of net7.0
     - Updated package references to versions compatible with .NET 9.0:
       - Microsoft.Data.Sqlite: 7.0.14 → 9.0.0
       - Microsoft.NET.Test.Sdk: 17.8.0 → 17.9.0
       - Moq: 4.20.69 → 4.20.70
       - NUnit: 3.13.3 → 4.0.1
       - NUnit3TestAdapter: 4.4.2 → 4.5.0
       - NUnit.Analyzers: 3.6.1 → 3.10.0
     - Updated test assertions to use NUnit 4.0 syntax
     - Updated README to reference .NET 9.0

     This update addresses the "end of life" warning for .NET 7.0 and ensures the project uses a currently supported .NET version.